### PR TITLE
Add support for subfolder partials with same name

### DIFF
--- a/lib/loadPartials.js
+++ b/lib/loadPartials.js
@@ -6,13 +6,15 @@ var utils = require('./utils');
  * Looks for files with .html, .hbs, or .handlebars extensions within the given directory, and adds them as Handlebars partials matching the name of the file.
  * @param {string} dir - Folder to check for partials.
  */
-module.exports = function(dir) {
-  var partials = utils.loadFiles(dir, '**/*.{html,hbs,handlebars}');
+module.exports = function (dir) {
+  var full_dir_path = (process.cwd() + '/' + dir).replace(/\\/g, '/') + (dir.indexOf('/', dir.length - 1) !== -1 ? '/' : ''),
+    partials = utils.loadFiles(dir, '**/*.{html,hbs,handlebars}');
 
   for (var i in partials) {
-    var ext = path.extname(partials[i]);
-    var file = fs.readFileSync(partials[i]);
-    var name = path.basename(partials[i], ext);
+    var ext = path.extname(partials[i]),
+      file = fs.readFileSync(partials[i]),
+      name = partials[i].substring(full_dir_path.length, partials[i].length - ext.length);
+
     this.Handlebars.registerPartial(name, file.toString() + '\n');
   }
 }

--- a/lib/loadPartials.js
+++ b/lib/loadPartials.js
@@ -7,7 +7,7 @@ var utils = require('./utils');
  * @param {string} dir - Folder to check for partials.
  */
 module.exports = function (dir) {
-  var full_dir_path = (process.cwd() + '/' + dir).replace(/\\/g, '/') + (dir.indexOf('/', dir.length - 1) !== -1 ? '/' : ''),
+  var full_dir_path = (process.cwd() + '/' + dir).replace(/\\/g, '/') + (dir.indexOf('/', dir.length - 1) == -1 ? '/' : ''),
     partials = utils.loadFiles(dir, '**/*.{html,hbs,handlebars}');
 
   for (var i in partials) {


### PR DESCRIPTION
Instead of using the basename as partial name, use file path (without extension) relative to the configured partial folder.

Fix issue #22